### PR TITLE
disable afterburner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,6 @@ Changelog
 -----
 
 * Disable Afterburner and Mr Bean by default. This will cost in deserialization performance, but prevent some
-Java 9 reflection issues. (Revisit post Jackson 3). These are configurable with the boolean switches
-`ot.jackson.afterburner`, `ot.jackson.mrbean`
+Java 9+ reflection issues. (Revisit post Jackson 3). These are configurable with the boolean switches
+`ot.jackson.afterburner`, `ot.jackson.mrbean` - but be aware ASM might be updated (and is a dependency). 
+When shipped, ASM was version 5.2 - which isn't J9+ compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@ Changelog
 2.1.3
 -----
 
-* Disable Afterburner by default. This will cost in deserialization performance, but prevent some
-Java 9 reflection issues. (Revisit post Jackson 3)
+* Disable Afterburner and Mr Bean by default. This will cost in deserialization performance, but prevent some
+Java 9 reflection issues. (Revisit post Jackson 3). These are configurable with the boolean switches
+`ot.jackson.afterburner`, `ot.jackson.mrbean`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+2.1.3
+-----
+
+* Disable Afterburner by default. This will cost in deserialization performance, but prevent some
+Java 9 reflection issues. (Revisit post Jackson 3)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>139</version>
+    <version>159</version>
   </parent>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>159</version>
+    <version>160</version>
   </parent>
 
   <scm>

--- a/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
+++ b/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
@@ -42,10 +42,10 @@ public class OpenTableJacksonConfiguration
     JacksonTimeFormat timeFormat = JacksonTimeFormat.ISO8601;
 
     @Value("${ot.jackson.afterburner:#{false}}")
-    private final boolean enableAfterBurner;
+    private boolean enableAfterBurner;
 
     @Value("${ot.jackson.mrbean:#{false}}")
-    private final boolean enableMrBean;
+    private boolean enableMrBean;
 
     @Bean
     public ObjectMapper objectMapper() {

--- a/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
+++ b/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
@@ -42,7 +42,10 @@ public class OpenTableJacksonConfiguration
     JacksonTimeFormat timeFormat = JacksonTimeFormat.ISO8601;
 
     @Value("${ot.jackson.afterburner:#{false}}")
-    private boolean enableAfterBurner = false;
+    private final boolean enableAfterBurner;
+
+    @Value("${ot.jackson.mrbean:#{false}}")
+    private final boolean enableMrBean;
 
     @Bean
     public ObjectMapper objectMapper() {
@@ -50,9 +53,11 @@ public class OpenTableJacksonConfiguration
 
         mapper.registerModules( guavaModule(),
                                 javaTimeModule(),
-                                mrBeanModule(),
                                 jdk8Module(),
                                 parameterNamesModule());
+        if (enableMrBean) {
+            mapper.registerModule(mrBeanModule());
+        }
         if (enableAfterBurner) {
             mapper.registerModule(afterburnerModule());
         }

--- a/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
+++ b/src/main/java/com/opentable/jackson/OpenTableJacksonConfiguration.java
@@ -41,6 +41,9 @@ public class OpenTableJacksonConfiguration
     @Value("${ot.jackson.time-format:ISO8601}")
     JacksonTimeFormat timeFormat = JacksonTimeFormat.ISO8601;
 
+    @Value("${ot.jackson.afterburner:#{false}}")
+    private boolean enableAfterBurner = false;
+
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
@@ -48,9 +51,11 @@ public class OpenTableJacksonConfiguration
         mapper.registerModules( guavaModule(),
                                 javaTimeModule(),
                                 mrBeanModule(),
-                                afterburnerModule(),
                                 jdk8Module(),
                                 parameterNamesModule());
+        if (enableAfterBurner) {
+            mapper.registerModule(afterburnerModule());
+        }
 
         // This needs to be set, otherwise the mapper will fail on every new property showing up.
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);


### PR DESCRIPTION
Afterburner speeds deserialization but uses ASM 5.2, which is problematic. It also generates a lot of illegal reflective accress warnings in java 9.

Jackson 3 will fix by switching to byte buddy and be fully J11+ compatible, but release date, backwards compatiblity up in air.

Also possible (and needed for full ASM 5.2 independence AFAIK) - stop configuring mrbean. Need to check opengrok to see if that will cause issues.